### PR TITLE
added multi-file compilation using threads + llvm refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,23 @@ emc <FILE_PATH>
 ```
 
 The file must have a .em extension.
+To compile multiple files at once:
+
+```
+emc <FILE_1> <FILE_2> ... <FILE_n>
+```
 
 ## Flags
 
 We can add some compilation flags when compiling, as:
 
 ```
-emc <FILE_PATH> ...
-                 ^ flags (optional)
+emc <FILE_1> <FILE_2> ... <FILE_n> ...
+                                    ^ flags (optional)
 ```
+
+A flag is identified as something that starts with a hyphen (-).
+Everything before the first flag will be treated as a file to be compiled.
 
 Here are the flags that can be added, along with their purposes:
 

--- a/lexer.h
+++ b/lexer.h
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <vector>
 #include <iterator>
+#include <stack>
 #include "data_structures.h"
 
 

--- a/main.cpp
+++ b/main.cpp
@@ -32,16 +32,42 @@ machine.
 Additionally, we would like to handle any flags that are
 passed.
 
+For the compilation of multiple files, we would make use
+of threads to run the compilation process in parallel.
+
 */
 
 #include "ir_generator.h"
 #include <chrono>
+#include <thread>
+#include <mutex>
 
 #define LANGUAGE_FILE_EXTENSION "em"
 
 
 
 enum Output_File_Type { OBJ, ASM };
+
+
+struct Flag_Settings
+{
+    bool make_output_file = true;
+    bool print_ast = false;
+    bool print_ir = false;
+    bool make_ll_file = false;
+    Output_File_Type output_file_type = OBJ;
+    std::string cpu_type;
+};
+
+
+struct Compilation_Metrics
+{
+    int total_lines = 0;
+    double frontend_time = 0;
+    double backend_time = 0;
+    double total_time = 0;
+};
+
 
 const std::string cpu_to_target[][2] = {
     /* Windows/Linux x86 systems */
@@ -72,7 +98,7 @@ const std::string cpu_to_target[][2] = {
     {"neoverse-n2", "aarch64-unknown-linux-gnu"}
 };
 
-const int num_cpu_types = sizeof(cpu_to_target) / sizeof(cpu_to_target[0]);
+const int NUM_CPU_TYPES = sizeof(cpu_to_target) / sizeof(cpu_to_target[0]);
 
 
 
@@ -138,25 +164,15 @@ void run_llvm_backend(
 }
 
 
-// displays the frontend, backend, and total elapsed times.
-void print_benchmark_metrics(
-    std::chrono::time_point<std::chrono::high_resolution_clock> frontend_start,
-    std::chrono::time_point<std::chrono::high_resolution_clock> frontend_end,
-    std::chrono::time_point<std::chrono::high_resolution_clock> backend_end,
-    int total_lines_of_code
-) {
-    // calculating the elapsed time duration in seconds
-    std::chrono::duration<double> frontend_elapsed_time = frontend_end - frontend_start;
-    std::chrono::duration<double> backend_elapsed_time = backend_end - frontend_end;
-
+// displays the total lines, and the frontend, backend, and total elapsed times.
+void print_benchmark_metrics(Compilation_Metrics *metrics)
+{
     printf("\n         Performance metrics\n");
     printf("-------------------------------------\n");
-    printf("Total lines of code: \t%d lines\n", total_lines_of_code);
-    printf("Frontend time elapsed: \t%.6f sec\n", frontend_elapsed_time.count());
-    printf("Backend time elapsed: \t%.6f sec\n", backend_elapsed_time.count());
-
-    double total_time = frontend_elapsed_time.count() + backend_elapsed_time.count();
-    printf("Total execution time: \t%.6f sec\n", total_time);
+    printf("Total lines of code: \t%d lines\n", metrics->total_lines);
+    printf("Frontend time elapsed: \t%.6f sec\n", metrics->frontend_time);
+    printf("Backend time elapsed: \t%.6f sec\n", metrics->backend_time);
+    printf("Total execution time: \t%.6f sec\n", metrics->total_time);
 }
 
 
@@ -168,6 +184,76 @@ int has_extension(const char *file_name, const char *ext) {
 }
 
 
+// perform the entire compilation process (frontend + backend) for a file.
+// also updates the overall compilation metrics as per the metrics for this file.
+void compile(
+    const char *file_name,
+    Flag_Settings *flag_settings,
+    std::chrono::time_point<std::chrono::high_resolution_clock> frontend_start,
+    Compilation_Metrics *metrics,
+    std::mutex *metrics_mutex
+) {
+    if (!has_extension(file_name, LANGUAGE_FILE_EXTENSION)) {
+	fprintf(stderr, "ERROR: Invalid file type (%s). File must have a .%s extension.", file_name, LANGUAGE_FILE_EXTENSION);
+	exit(1);
+    }
+
+    Lexer *lexer = perform_lexical_analysis(file_name);
+    auto *ast = parse_tokens(lexer);
+    LLVM_IR *ir = emit_llvm_ir(ast, lexer->file_name.c_str());
+
+    auto frontend_end = std::chrono::high_resolution_clock::now();
+
+    // handle compiler flags
+    if (flag_settings->print_ast) print_ast(ast);
+    if (flag_settings->print_ir) print_ir(ir->_module);
+    if (flag_settings->make_ll_file) {
+	std::string llvm_file_name = lexer->file_name + ".ll";
+	write_llvm_ir_to_file(llvm_file_name.c_str(), ir->_module);
+    }
+
+    std::string target_triple;
+    if (flag_settings->cpu_type != "") {
+	for (int i = 0; i < NUM_CPU_TYPES; i++) {
+	    if (cpu_to_target[i][0] == flag_settings->cpu_type) {
+		target_triple = cpu_to_target[i][1];
+		break;
+	    }
+	}
+    }
+    if (target_triple == "") flag_settings->cpu_type = "generic";
+
+    if (flag_settings->make_output_file) {
+	std::string file_extension = flag_settings->output_file_type == OBJ ? ".o" : ".s";
+	std::string output_file_name = lexer->file_name + file_extension;
+	run_llvm_backend(
+	    ir->_module,
+	    output_file_name,
+	    flag_settings->output_file_type,
+	    flag_settings->cpu_type,
+	    target_triple
+	);
+    }
+    auto backend_end = std::chrono::high_resolution_clock::now();
+
+    {
+	std::lock_guard<std::mutex> lock(*metrics_mutex);
+	metrics->total_lines += lexer->total_lines_postprocessing;
+
+	// calculating the elapsed time duration in seconds
+	std::chrono::duration<double> frontend_elapsed_time = frontend_end - frontend_start;
+	std::chrono::duration<double> backend_elapsed_time = backend_end - frontend_end;
+
+	metrics->frontend_time += frontend_elapsed_time.count();
+	metrics->backend_time += backend_elapsed_time.count();
+    }
+
+    // cleaning up allocated memory
+    delete lexer;
+    delete ast;
+}
+
+
 int main(int argc, char **argv)
 {
     // keeping track of the execution time for benchmarking metrics
@@ -175,8 +261,8 @@ int main(int argc, char **argv)
     /*
     The basic compilation command should be something like:
 
-	<compiler> "<PATH_TO_FILE>" ...
-	                             ^ flags (optional)
+	<compiler> <FILE_1> ... <FILE_n> ...
+	                                  ^ flags (optional)
     */
 
     if (argc < 2) {
@@ -184,72 +270,47 @@ int main(int argc, char **argv)
 	exit(1);
     }
 
-    const char *file_name = argv[1];
-    if (!has_extension(file_name, LANGUAGE_FILE_EXTENSION)) {
-	fprintf(stderr, "ERROR: Invalid file type. File must have a .%s extension.", LANGUAGE_FILE_EXTENSION);
-	exit(1);
+    int flags_start_index = 1;
+    for (int i = 1; i < argc; i++) {
+	if (argv[i][0] == '-') {
+	    flags_start_index = i;
+	    break;
+	}
     }
 
-    Lexer *lexer = perform_lexical_analysis(file_name);
-    auto *ast = parse_tokens(lexer);
-
-    llvm::LLVMContext _context;                // holds global LLVM state
-    llvm::Module _module(lexer->file_name.c_str(), _context); // container for functions/vars
-    llvm::IRBuilder<> _builder(_context);      // helper to generate instructions
-
-    emit_llvm_ir(ast, _context, &_builder, &_module);
-    auto frontend_end = std::chrono::high_resolution_clock::now();
-
-
+    Flag_Settings flag_settings;
     bool show_benchmarking_metrics = false;
-    bool make_output_file = true;
-    Output_File_Type output_file_type = OBJ;
-    std::string cpu_type;
 
-    // handle the compiler flags (if any are provided by the user)
-    for (int i = 2; i < argc; i++) {
-	if (strcmp(argv[i], "-pout") == 0) print_ast(ast);
-	else if (strcmp(argv[i], "-llout") == 0) print_ir(&_module);
+    // set the compiler flag settings
+    for (int i = flags_start_index; i < argc; i++) {
+	if (strcmp(argv[i], "-pout") == 0) flag_settings.print_ast = true;
+	else if (strcmp(argv[i], "-llout") == 0) flag_settings.print_ir = true;
 	else if (strcmp(argv[i], "-ll") == 0) {
-	    std::string llvm_file_name = lexer->file_name + ".ll";
-	    write_llvm_ir_to_file(llvm_file_name.c_str(), &_module);
-	    make_output_file = false;
+	    flag_settings.make_ll_file = true;
+	    flag_settings.make_output_file = false;
 	}
-	else if (strcmp(argv[i], "-asm") == 0) output_file_type = ASM;
+	else if (strcmp(argv[i], "-asm") == 0) flag_settings.output_file_type = ASM;
 	else if (strcmp(argv[i], "-benchmark") == 0) show_benchmarking_metrics = true;
 	else if (strcmp(argv[i], "-cpu") == 0 && i < argc - 1) {
-	    cpu_type = argv[++i]; // reads the next argument as the cpu type
+	    flag_settings.cpu_type = argv[++i]; // reads the next argument as the cpu type
 	}
     }
 
-    std::string target_triple;
-    if (cpu_type != "") {
-	for (int i = 0; i < num_cpu_types; i++) {
-	    if (cpu_to_target[i][0] == cpu_type) {
-		target_triple = cpu_to_target[i][1];
-		break;
-	    }
-	}
-    }
-    if (target_triple == "") cpu_type = "generic";
+    // run the compilation process for each file in parallel
+    Compilation_Metrics metrics;
+    std::mutex metrics_mutex;
+    std::vector<std::thread> threads;
 
-    if (make_output_file) {
-	std::string file_extension = output_file_type == OBJ ? ".o" : ".s";
-	std::string output_file_name = lexer->file_name + file_extension;
-	run_llvm_backend(
-	    &_module,
-	    output_file_name,
-	    output_file_type,
-	    cpu_type,
-	    target_triple
-	);
+    for (int i = 1; i < flags_start_index; i++) {
+	threads.emplace_back([&, i]() {
+	    compile(argv[i], &flag_settings, frontend_start, &metrics, &metrics_mutex);
+	});
     }
-    auto backend_end = std::chrono::high_resolution_clock::now();
+    for (auto& t : threads) t.join(); // wait for all threads to finish
 
     if (show_benchmarking_metrics) {
-	int total_lines_of_code = lexer->total_lines_postprocessing;
-	print_benchmark_metrics(frontend_start, frontend_end, backend_end, total_lines_of_code);
+	metrics.total_time = metrics.frontend_time + metrics.backend_time;
+	print_benchmark_metrics(&metrics);
     }
-
     return 0;
 }


### PR DESCRIPTION
the changes are:

- now multiple files can be compiled at once by providing their file names/paths in the compilation command
- threading is used to compile multiple files in parallel
- the ir generator has been refactored, by packaging the context, builder and module into a single LLVM_IR object that can be shared around
- the llvm_symbol_table and loop_terminals objects that were previously defined globally, are now part of the LLVM_IR struct, thus preventing issues involving multiple threads mutating a shared global object.

resolves #11 
